### PR TITLE
Add created entity on post generation, fix override default values and allow subfactories to define attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This section provides examples on how to use this library's features.
 For declaring a factory, we make use of typescript classes and add as properties on the class the fields from our entity with the desired values
 
 ```typescript
+import { Factory } from '@linnify/typeorm-factory';
+
 export class NormalUserFactory extends Factory<User> {
   entity = User;
   
@@ -83,6 +85,8 @@ In the case when we have some unique attributes by which we define entities. We 
 In our example, we do not want to create 2 users with the same email.
 
 ```typescript
+import { Factory } from '@linnify/typeorm-factory';
+
 export class NormalUserFactory extends Factory<User> {
   ...
 
@@ -108,6 +112,8 @@ A common case is that the entities have relations between them. In this case we 
 If the user has multiple addresses we add the `UserFactory` as a subfactory on the `AddressFactory`
 
 ```typescript
+import { Factory, SubFactory } from '@linnify/typeorm-factory';
+
 export class AddressFactory extends Factory<Address> {
   street = 'Factory Street'
   number = '100'
@@ -120,6 +126,8 @@ export class AddressFactory extends Factory<Address> {
 We can add sequences on our factories when we want a property to have a different every time we create an object using the same factory
 
 ```typescript
+import { Factory, Sequence } from '@linnify/typeorm-factory';
+
 export class NormalUserFactory extends Factory<User> {
   ...
   email = new Sequence((i: number) => `john.doe.${i}@typeorm-factory.com`)
@@ -132,6 +140,8 @@ export class NormalUserFactory extends Factory<User> {
 Sometimes we have the need to call some functions after the object was created. For this, we have created a `PostGeneration` decorator that can be used on multiple functions and all of them will be called after the entity was created.
 
 ```typescript
+import { Factory, PostGeneration } from '@linnify/typeorm-factory';
+
 export class NormalUserFactory extends Factory<User> {
   ...
   
@@ -141,8 +151,8 @@ export class NormalUserFactory extends Factory<User> {
   }
   
   @PostGeneration()
-  anotherFunctionToBeCalled() {
-    
+  async anotherFunctionToBeCalled(createdUser: User) {
+    // do something with the created user
   }
 }
 ```

--- a/__tests__/entities/Company.ts
+++ b/__tests__/entities/Company.ts
@@ -1,5 +1,6 @@
-import {Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn} from "typeorm";
+import {Column, Entity, OneToMany, PrimaryGeneratedColumn} from "typeorm";
 import {Project} from "./Project";
+import {Employee} from "./Employee";
 
 @Entity()
 export class Company {
@@ -18,6 +19,12 @@ export class Company {
   @Column()
   website: string;
 
+  @Column()
+  active: boolean;
+
   @OneToMany(() => Project, (project) => project.company)
   projects: Project[];
+
+  @OneToMany(() => Employee, (employee) => employee.company)
+  employees: Employee[];
 }

--- a/__tests__/entities/Employee.ts
+++ b/__tests__/entities/Employee.ts
@@ -1,0 +1,18 @@
+import {Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import {Company} from "./Company";
+
+@Entity()
+export class Employee {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  firstName: string;
+
+  @Column()
+  lastName: string;
+
+  @ManyToOne(() => Company)
+  @JoinColumn()
+  company: Company;
+}

--- a/__tests__/entities/index.ts
+++ b/__tests__/entities/index.ts
@@ -1,5 +1,6 @@
 import {Company} from "./Company";
 import {Project} from "./Project";
 import {User} from "./User";
+import {Employee} from "./Employee";
 
-export const entities = [Company, Project, User];
+export const entities = [Company, Project, User, Employee];

--- a/__tests__/factories/company.factory.ts
+++ b/__tests__/factories/company.factory.ts
@@ -1,6 +1,7 @@
 import {Company} from "../entities/Company";
 import {Factory} from "../../src";
 import {PostGeneration} from "../../src/decorators";
+import {EmployeeFactory} from "./employee.factory";
 
 const myFunction = () => {
   console.log(new Date());
@@ -13,10 +14,11 @@ export class CompanyFactory extends Factory<Company> {
   numberOfEmployees = 40
   description = 'Simplifying life through innovation'
   website = 'https://linnify.com'
+  active = true;
 
   @PostGeneration()
-  createLog() {
-    console.log('Company created!');
+  async createLog(company: Company) {
+    company.employees = await new EmployeeFactory().createMany(5, {company});
   }
 
   @PostGeneration()

--- a/__tests__/factories/employee.factory.ts
+++ b/__tests__/factories/employee.factory.ts
@@ -1,0 +1,11 @@
+import {Employee} from "../entities/Employee";
+import {Factory, SubFactory} from "../../src";
+import {CompanyFactory} from "./company.factory";
+
+export class EmployeeFactory extends Factory<Employee> {
+  entity = Employee;
+
+  firstName = 'Darius'
+  lastName = 'Bogdan'
+  company = new SubFactory(CompanyFactory)
+}

--- a/__tests__/factories/user.factory.ts
+++ b/__tests__/factories/user.factory.ts
@@ -8,7 +8,7 @@ export class UserFactory extends Factory<User> {
   firstName = 'Darius'
   lastName = 'Bogdan'
   email = 'darius.bogdan@linnify.com'
-  company = new SubFactory(CompanyFactory)
+  company = new SubFactory(CompanyFactory, {name: 'TypeORM Factory'})
 
   protected getOrCreate(): string[] {
     return ['email']

--- a/__tests__/factory.test.ts
+++ b/__tests__/factory.test.ts
@@ -119,14 +119,29 @@ describe('Test factories',() => {
   })
 
   it('Should call the post generation functions after creating the entity', async () => {
-    const companyFactory: CompanyFactory = await new CompanyFactory();
+    const companyFactory: CompanyFactory = new CompanyFactory();
     const createLogSpy = sinon.spy(companyFactory, 'createLog');
     const callAFunctionSpy = sinon.spy(companyFactory, 'callAFunction')
 
-    await companyFactory.create();
+    const company = await companyFactory.create();
 
     expect(createLogSpy.calledOnce).toBeTruthy();
     expect(callAFunctionSpy.calledOnce).toBeTruthy();
     expect(FactoryStorage.storage.getPostGenerators('CompanyFactory').length).toEqual(2);
+    expect(company.employees.length).toEqual(5);
+  })
+
+  it('Should allow overriding boolean factory default value to false', async () => {
+    const companyFactory: CompanyFactory = new CompanyFactory();
+
+    const createdCompany = await companyFactory.create({active: false});
+
+    expect(createdCompany.active).toEqual(false);
+  })
+
+  it('Should allow changing the subfactory default values', async () => {
+    const user = await new UserFactory().create();
+
+    expect(user.company.name).toEqual('TypeORM Factory');
   })
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './sequence';
 export * from './subfactory';
 export * from './types';
 export * from './factory-storage';
+export * from './decorators';

--- a/src/subfactory.ts
+++ b/src/subfactory.ts
@@ -3,8 +3,10 @@ import { Factory } from './factory';
 
 export class SubFactory<T> {
   factory: Factory<T>;
+  values: Partial<T> | undefined;
 
-  constructor(factory: FactoryClass<T>) {
+  constructor(factory: FactoryClass<T>, values?: Partial<T>) {
     this.factory = new factory();
+    this.values = values;
   }
 }


### PR DESCRIPTION
- Improve README
- Change default values with any value sent as param to create (allow sending false and null values)
- Allow defining values on subfactories to override the default values on the subfactory

Closes #9 , Closes #7 , Closes #3 